### PR TITLE
Fixed Delete Button

### DIFF
--- a/client/actions/todos/deleteTodo.js
+++ b/client/actions/todos/deleteTodo.js
@@ -4,7 +4,7 @@ import axios from 'axios';
 import {DELETE_TODO} from '../types';
 
 export default function (id, callback) {
-    const request = axios.delete(`/api/todos/id`)
+    const request = axios.delete(`/api/todos/${id}`)
                          .then(() => {
                             callback();
                          });


### PR DESCRIPTION
A client informed me that they were not able to delete any items from the To Do app.  Upon further inspection, I found the source of error to be in the reducer.  Specifically that the id of the todo item was not being sent in the request body due to a syntax error.  

I've corrected the syntax error and now the button works as expected.

![to do](https://user-images.githubusercontent.com/16406332/40883415-383802c2-66ca-11e8-994a-f94472e76a01.gif)
